### PR TITLE
Deploy GitLab runners

### DIFF
--- a/apps/scripts/deploy_secrets
+++ b/apps/scripts/deploy_secrets
@@ -25,7 +25,7 @@ notifications_smtp_access_key=$(echo $secret | jq -jr .smtp_access_key_id | base
 notifications_smtp_key_secret=$(echo $secret | jq -jr .smtp_access_key_secret | base64)
 grafana_admin_username=$(echo $secret | jq -jr .grafana_admin_username)
 grafana_admin_password=$(echo $secret | jq -jr .grafana_admin_password)
-gitlab_group_runner_token=$(echo $secret | jq -jr .gitlab_group_runner_token)
+gitlab_group_runner_token=$(echo $secret | jq -jr .gitlab_group_runner_token | base64)
 
 source ../config/environment_$DEPLOYMENT_STAGE &&\
 helm upgrade secrets secrets\

--- a/apps/scripts/deploy_secrets
+++ b/apps/scripts/deploy_secrets
@@ -25,6 +25,7 @@ notifications_smtp_access_key=$(echo $secret | jq -jr .smtp_access_key_id | base
 notifications_smtp_key_secret=$(echo $secret | jq -jr .smtp_access_key_secret | base64)
 grafana_admin_username=$(echo $secret | jq -jr .grafana_admin_username)
 grafana_admin_password=$(echo $secret | jq -jr .grafana_admin_password)
+gitlab_group_runner_token=$(echo $secret | jq -jr .gitlab_group_runner_token)
 
 source ../config/environment_$DEPLOYMENT_STAGE &&\
 helm upgrade secrets secrets\
@@ -43,4 +44,5 @@ helm upgrade secrets secrets\
     --set awsKeys.notificationsSmtpPassword=$notifications_smtp_key_secret\
     --set awsKeys.grafanaAdminUsername=$grafana_admin_username\
     --set awsKeys.grafanaAdminPassword=$grafana_admin_password\
+    --set awsKeys.gitlabGroupRunnerToken=$gitlab_group_runner_token\
     --force --install

--- a/apps/secrets/templates/deployment.yaml
+++ b/apps/secrets/templates/deployment.yaml
@@ -4,10 +4,10 @@ data:
   archiver-api-key: {{ .Values.apiKeys.archiverApiKey }}
   staging-api-key: {{ .Values.apiKeys.stagingApiKey }}
   exporter-terra-auth-info: {{ .Values.apiKeys.exporterTerraAuthInfo }}
-  biostudies-api-username: {{ .Values.apiKeys.biostudiesApiUsername}}
-  biostudies-api-password: {{ .Values.apiKeys.biostudiesApiPassword}}
-  ena-webin-username: {{ .Values.apiKeys.enaWebinUsername}}
-  ena-webin-password: {{ .Values.apiKeys.enaWebinPassword}}
+  biostudies-api-username: {{ .Values.apiKeys.biostudiesApiUsername }}
+  biostudies-api-password: {{ .Values.apiKeys.biostudiesApiPassword }}
+  ena-webin-username: {{ .Values.apiKeys.enaWebinUsername }}
+  ena-webin-password: {{ .Values.apiKeys.enaWebinPassword }}
 kind: Secret
 metadata:
   annotations: {}
@@ -24,6 +24,7 @@ data:
   notifications-smtp-username: {{ .Values.awsKeys.notificationsSmtpUsername }}
   notifications-smtp-password: {{ .Values.awsKeys.notificationsSmtpPassword }}
   runner-registration-token: {{ .Values.awsKeys.gitlabGroupRunnerToken }}
+  runner-token: ""
 stringData:
   grafana-admin-username: {{ .Values.awsKeys.grafanaAdminUsername }}
   grafana-admin-password: {{ .Values.awsKeys.grafanaAdminPassword }}

--- a/apps/secrets/templates/deployment.yaml
+++ b/apps/secrets/templates/deployment.yaml
@@ -23,6 +23,7 @@ data:
   exporter-access-key-secret: {{ .Values.awsKeys.exporterAccessKeySecret }}
   notifications-smtp-username: {{ .Values.awsKeys.notificationsSmtpUsername }}
   notifications-smtp-password: {{ .Values.awsKeys.notificationsSmtpPassword }}
+  runner-registration-token: {{ .Values.awsKeys.gitlabGroupRunnerToken }}
 stringData:
   grafana-admin-username: {{ .Values.awsKeys.grafanaAdminUsername }}
   grafana-admin-password: {{ .Values.awsKeys.grafanaAdminPassword }}

--- a/infra/helm-charts/gitlab-runner/.helmignore
+++ b/infra/helm-charts/gitlab-runner/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/helm-charts/gitlab-runner/Chart.lock
+++ b/infra/helm-charts/gitlab-runner/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gitlab-runner
+  repository: https://charts.gitlab.io
+  version: 0.36.0
+digest: sha256:5b739ab28b34089adbf0736991195413bc0646ff00bae0971234f56ed0e5b41b
+generated: "2021-12-21T20:49:37.33686704Z"

--- a/infra/helm-charts/gitlab-runner/Chart.yaml
+++ b/infra/helm-charts/gitlab-runner/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: gitlab-runner
+description: Creates a GitLab runner that is used to run ingest CI/CD pipelines
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+dependencies:
+  - name: "gitlab-runner"
+    version: 0.36.0
+    repository: "https://charts.gitlab.io"

--- a/infra/helm-charts/gitlab-runner/environments/dev.yaml
+++ b/infra/helm-charts/gitlab-runner/environments/dev.yaml
@@ -1,0 +1,3 @@
+gitlab-runner:
+  runners:
+    name: "ingest-eks-dev runner"

--- a/infra/helm-charts/gitlab-runner/templates/_helpers.tpl
+++ b/infra/helm-charts/gitlab-runner/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gitlab-runner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gitlab-runner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gitlab-runner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gitlab-runner.labels" -}}
+helm.sh/chart: {{ include "gitlab-runner.chart" . }}
+{{ include "gitlab-runner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gitlab-runner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gitlab-runner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gitlab-runner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gitlab-runner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infra/helm-charts/gitlab-runner/templates/service-account.yaml
+++ b/infra/helm-charts/gitlab-runner/templates/service-account.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-admin
+  namespace: dev-environment
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: gitlab-ci
+  name: gitlab-admin
+rules:
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["*"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-admin
+  namespace: gitlab-ci
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-admin
+    namespace: dev-environment
+roleRef:
+  kind: Role
+  name: gitlab-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/helm-charts/gitlab-runner/values.yaml
+++ b/infra/helm-charts/gitlab-runner/values.yaml
@@ -34,7 +34,7 @@ gitlab-runner:
           mount_path = "/certs/client"
           medium = "Memory"
 
-    tags: "ingest,dind"
+    tags: "ingest,dind,kubernetes"
     runUntagged: true
     name: "Ingest GitLab Runner"
     privileged: true

--- a/infra/helm-charts/gitlab-runner/values.yaml
+++ b/infra/helm-charts/gitlab-runner/values.yaml
@@ -34,7 +34,10 @@ gitlab-runner:
           mount_path = "/certs/client"
           medium = "Memory"
 
-    tags: "ingest,dind,kubernetes"
+    # NOTE: IN order to run integration tests
+    # The ingest-eks-node-{ENV} role must have access to perform secrets:GetSecretValue on:
+    # ingest/dev/secrets, hca/util/aws-access-keys, and ingest/dev/gcp-credentials.json
+    tags: "ingest,dind,kubernetes,ingest-integration-tests"
     runUntagged: true
     name: "Ingest GitLab Runner"
     privileged: true

--- a/infra/helm-charts/gitlab-runner/values.yaml
+++ b/infra/helm-charts/gitlab-runner/values.yaml
@@ -10,12 +10,6 @@ gitlab-runner:
   ##
   gitlabUrl: https://gitlab.ebi.ac.uk/
 
-  ## The Registration Token for adding new Runners to the GitLab Server. This must
-  ## be retrieved from your GitLab Instance.
-  ## ref: https://docs.gitlab.com/ce/ci/runners/README.html
-  ##
-  runnerRegistrationToken: "" # TODO ADD THIS TO SECRETS
-
   ## Configure the maximum number of concurrent jobs
   ## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
   ##
@@ -41,7 +35,11 @@ gitlab-runner:
           medium = "Memory"
 
     tags: "ingest,dind"
+    runUntagged: true
     name: "Ingest GitLab Runner"
+    privileged: true
+    # The secret containing runner-registration-token
+    secret: aws-keys
 
   rbac:
     create: false

--- a/infra/helm-charts/gitlab-runner/values.yaml
+++ b/infra/helm-charts/gitlab-runner/values.yaml
@@ -36,7 +36,8 @@ gitlab-runner:
 
     # NOTE: IN order to run integration tests
     # The ingest-eks-node-{ENV} role must have access to perform secrets:GetSecretValue on:
-    # ingest/dev/secrets, hca/util/aws-access-keys, and ingest/dev/gcp-credentials.json
+    # ingest/dev/secrets, hca/util/aws-access-keys, and ingest/dev/gcp-credentials.json 
+    # The "secrets-access-for-integration-tests-runner" role the appropriate access
     tags: "ingest,dind,kubernetes,ingest-integration-tests"
     runUntagged: true
     name: "Ingest GitLab Runner"

--- a/infra/helm-charts/gitlab-runner/values.yaml
+++ b/infra/helm-charts/gitlab-runner/values.yaml
@@ -1,0 +1,48 @@
+gitlab-runner:
+  ## How many runner pods to launch.
+  ##
+  ## Note: Using more than one replica is not supported with a runnerToken. Use a runnerRegistrationToken
+  ## to create multiple runner replicas.
+  replicas: 1
+
+  ## The GitLab Server URL (with protocol) that want to register the runner against
+  ## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
+  ##
+  gitlabUrl: https://gitlab.ebi.ac.uk/
+
+  ## The Registration Token for adding new Runners to the GitLab Server. This must
+  ## be retrieved from your GitLab Instance.
+  ## ref: https://docs.gitlab.com/ce/ci/runners/README.html
+  ##
+  runnerRegistrationToken: "" # TODO ADD THIS TO SECRETS
+
+  ## Configure the maximum number of concurrent jobs
+  ## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+  ##
+  concurrent: 10
+
+  ## Configuration for the Pods that the runner launches for each new job
+  ##
+  runners:
+    # runner configuration, where the multi line strings is evaluated as
+    # template so you can specify helm values inside of it.
+    #
+    # tpl: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+    # runner configuration: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+    config: |
+      [[runners]]
+        [runners.kubernetes]
+          namespace = "gitlab-ci"
+          image = "ubuntu:20.04"
+          privileged = true
+        [[runners.kubernetes.volumes.empty_dir]]
+          name = "docker-certs"
+          mount_path = "/certs/client"
+          medium = "Memory"
+
+    tags: "ingest,dind"
+    name: "Ingest GitLab Runner"
+
+  rbac:
+    create: false
+    serviceAccountName: gitlab-admin


### PR DESCRIPTION
dcp-260

- Deploys own gitlab runners so we don't have to rely on the shared EBI ones
- GitLab runner uses the [kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes.html)
  - This deploys a pod in the `gitlab-ci` namespace for each CI job
- Our GitLab runners are tagged with `ingest`, `kubernetes` and `dind`
- The token is set via AWS secrets and is currently a token for group wide runner meaning this runner can be used by any project in the `HCA` group
- This is currently running in dev
- I haven't added values for `staging` or `prod` since I think it's best if we only deploy this to `dev` since it will use resources