### PR TITLE
Project catalogue update fixes

### DIFF
--- a/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
+++ b/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
@@ -25,7 +25,7 @@ def get_publications_journal(project):
 
             if len(crossref['container-title']) > 0:
                 journal_title = crossref['container-title'][0]
-            elif "name" in crossref['institution']:
+            elif 'institution' in crossref and 'name' in crossref['institution']:
                 # BioRxiv is listed under institution
                 journal_title = crossref['institution']['name']
             else:

--- a/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
+++ b/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
@@ -38,8 +38,9 @@ def get_publications_journal(project):
                 "title": publication['title'],
                 "authors": publication['authors']
             })
-        except:
+        except Exception as e:
             logging.error(f"Something went wrong retrieving metainformation for publication {publication['doi']} for project {project['uuid']['uuid']}")
+            logging.error(f"Error: {e}")
     return results
 
 

--- a/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
+++ b/cron-jobs/update-project-catalogue/docker-app/scripts/populate.py
@@ -73,7 +73,7 @@ def patch_project(uuid, project, token=None):
         if "publications" in project["content"]:
             publications_info = get_publications_journal(project)
 
-            if "publicationsInfo" not in project or publications_info != project['publicationsInfo']:
+            if "publicationsInfo" not in project or publications_info != project['publicationsInfo'] and len(publications_info) > 0:
                 project_patch["publicationsInfo"] = publications_info
                 
                 # Remove all publicationsInfo first

--- a/cron-jobs/update-project-catalogue/docker-app/version.sh
+++ b/cron-jobs/update-project-catalogue/docker-app/version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 DOCKER_REPO=quay.io/ebi-ait/ingest-kube-deployment
-DOCKER_TAG=update-project-catalogue_20221102.6
+DOCKER_TAG=update-project-catalogue_20220103.1

--- a/cron-jobs/update-project-catalogue/docker-app/version.sh
+++ b/cron-jobs/update-project-catalogue/docker-app/version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 DOCKER_REPO=quay.io/ebi-ait/ingest-kube-deployment
-DOCKER_TAG=update-project-catalogue_20220103.2
+DOCKER_TAG=update-project-catalogue_20220103.3

--- a/cron-jobs/update-project-catalogue/docker-app/version.sh
+++ b/cron-jobs/update-project-catalogue/docker-app/version.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 DOCKER_REPO=quay.io/ebi-ait/ingest-kube-deployment
-DOCKER_TAG=update-project-catalogue_20220103.1
+DOCKER_TAG=update-project-catalogue_20220103.2

--- a/cron-jobs/update-project-catalogue/values.yaml
+++ b/cron-jobs/update-project-catalogue/values.yaml
@@ -7,4 +7,4 @@ image:
   tag: provide_through_set_flag
   pullPolicy: Always
 schedule: 0 22 * * *
-projectCount: 100
+projectCount: 1000


### PR DESCRIPTION
- Update the count so we query all projects in the catalogue. Ida is doing work on updating old projects so now we need this.
- Add actual error to log
- If the publications returned is an empty array, do nothing
  - Stops publicationsInfo being overriden if an error occurs when getting publications from crossref (e.g. 504)
- Check institution exists before using it
  - There is one DOI ([10.21203/rs.3.pex-953/v2](https://doi.org/10.21203/rs.3.pex-953/v2)) in the catalogue that this key doesn't exist in the response so it caused an error