### PR TITLE
Set resource limits and requests, enable vertical autoscaling, fix metrics-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ If you would like to change the dashboard for Ingest Monitoring, you must save t
 4. `cd infra && make upgrade upgrade-infra-helm-chart-ingest-monitoring` 
   - The script will replace any references to e.g. prod-environment with the environment you are deploying to. 
 
+### Vertical autoscaling
+Vertical autoscaling can be deployed to give recommendations on CPU and memory constraints for containers. See `infra/vertical-autoscaling/README.md`.
+
 ## Deploy CRON jobs
 CRON jobs are located in `cron-jobs/`. Further details for deploying and updating CRON jobs are located in `cron-jobs/README.md` and details on individual CRON jobs are found in their helm chart's READMEs.
 

--- a/apps/ingest-archiver/templates/deployment.yaml
+++ b/apps/ingest-archiver/templates/deployment.yaml
@@ -80,3 +80,8 @@ spec:
         name: ingest-archiver
         ports:
         - containerPort: 5000
+        resources:
+          limits:
+            memory: 95Mi
+          requests:
+            memory: 60Mi

--- a/apps/ingest-broker/templates/deployment.yaml
+++ b/apps/ingest-broker/templates/deployment.yaml
@@ -43,3 +43,8 @@ spec:
         volumeMounts:
         - mountPath: /data/spreadsheets
           name: spreadsheet-storage
+        resources:
+          limits:
+            memory: 1.5Gi # 1536 Mib
+          requests:
+            memory: 400Mi

--- a/apps/ingest-core/templates/deployment.yaml
+++ b/apps/ingest-core/templates/deployment.yaml
@@ -78,3 +78,8 @@ spec:
             port: http
           initialDelaySeconds: 60
           periodSeconds: 3
+        resources:
+          limits:
+            memory: 2.5Gi
+          requests:
+            memory: 1.2Gi

--- a/apps/ingest-core/templates/deployment.yaml
+++ b/apps/ingest-core/templates/deployment.yaml
@@ -80,6 +80,6 @@ spec:
           periodSeconds: 3
         resources:
           limits:
-            memory: 2.5Gi
+            memory: 2.5Gi # 2560Mi
           requests:
-            memory: 1.2Gi
+            memory: 1.4Gi # 1434 Mi

--- a/apps/ingest-data-archiver/templates/deployment.yaml
+++ b/apps/ingest-data-archiver/templates/deployment.yaml
@@ -69,3 +69,8 @@ spec:
 #        volumeMounts:
 #        - mountPath: /data
 #          name: archiver-data
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            memory: 40Mi

--- a/apps/ingest-exporter/templates/deployment.yaml
+++ b/apps/ingest-exporter/templates/deployment.yaml
@@ -70,4 +70,9 @@ spec:
             readOnly: true
         imagePullPolicy: Always
         name: ingest-exporter
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            memory: 70Mi
       dnsPolicy: Default

--- a/apps/ingest-graph-validator/templates/deployment.yaml
+++ b/apps/ingest-graph-validator/templates/deployment.yaml
@@ -39,3 +39,8 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: Always
         name: ingest-graph-validator
+        resources:
+          limits:
+            memory: 1Gi # 1024 Mib
+          requests:
+            memory: 400Mi

--- a/apps/ingest-staging-manager/templates/deployment.yaml
+++ b/apps/ingest-staging-manager/templates/deployment.yaml
@@ -40,3 +40,8 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: Always
         name: ingest-staging-manager
+        resources:
+          limits:
+            memory: 40Mi
+          requests:
+            memory: 30Mi

--- a/apps/ingest-state-tracking/templates/deployment.yaml
+++ b/apps/ingest-state-tracking/templates/deployment.yaml
@@ -43,3 +43,8 @@ spec:
         name: ingest-state-tracking
         ports:
           - containerPort: 8999
+        resources:
+          limits:
+            memory: 700Mi
+          requests:
+            memory: 500Mi

--- a/apps/ingest-ui/templates/deployment.yaml
+++ b/apps/ingest-ui/templates/deployment.yaml
@@ -48,3 +48,8 @@ spec:
         ports:
         - containerPort: 4200
       dnsPolicy: Default
+      resources:
+          limits:
+            memory: 20Mi
+          requests:
+            memory: 15Mi

--- a/apps/ingest-validator/templates/deployment.yaml
+++ b/apps/ingest-validator/templates/deployment.yaml
@@ -55,3 +55,8 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: Always
         name: ingest-validator
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            memory: 140Mi

--- a/apps/ontology/templates/deployment.yaml
+++ b/apps/ontology/templates/deployment.yaml
@@ -26,3 +26,8 @@ spec:
         name: ontology
         ports:
         - containerPort: 8080
+        resources:
+          limits:
+            memory: 2.5Gi #2560 Mib
+          requests:
+            memory: 1.8Gi # 1843 Mib

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -83,6 +83,17 @@ install-infra-helm-chart-ingest-monitoring:
 upgrade-infra-helm-chart-ingest-monitoring:
 	./scripts/deploy_monitoring.sh --upgrade
 
+install-infra-helm-chart-vertical-autoscaling:
+	cd helm-charts && helm dependency update vertical-autoscaling && helm package vertical-autoscaling
+	cd helm-charts && helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install
+	cd helm-charts && rm *.tgz
+	kubectl label ns $(deployment_stage)-environment goldilocks.fairwinds.com/enabled=true --overwrite
+
+	@if [$(deployment_stage) = "dev"]; then\
+		echo "Turning on auto VPA update";\
+		kubectl label ns $(deployment_stage)-environment goldilocks.fairwinds.com/vpa-update-mode="auto" --overwrite
+	fi
+
 install-infra-helm-chart-%:
 	cd helm-charts && helm dependency update $(*) && helm package $(*)
 	. ../config/environment_$(deployment_stage) && cd helm-charts && helm upgrade --values $(*)/values.yaml --values $(*)/environments/$(deployment_stage).yaml $(*) ./$(*) --force --install

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -84,15 +84,10 @@ upgrade-infra-helm-chart-ingest-monitoring:
 	./scripts/deploy_monitoring.sh --upgrade
 
 install-infra-helm-chart-vertical-autoscaling:
-	cd helm-charts && helm dependency update vertical-autoscaling && helm package vertical-autoscaling
-	cd helm-charts && helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install
-	cd helm-charts && rm *.tgz
-	kubectl label ns $(deployment_stage)-environment goldilocks.fairwinds.com/enabled=true --overwrite
+	./scripts/deploy_vertical_autoscaling.sh
 
-	@if [$(deployment_stage) = "dev"]; then\
-		echo "Turning on auto VPA update";\
-		kubectl label ns $(deployment_stage)-environment goldilocks.fairwinds.com/vpa-update-mode="auto" --overwrite
-	fi
+upgrade-infra-helm-chart-vertical-autoscaling:
+	./scripts/deploy_vertical_autoscaling.sh --upgrade
 
 install-infra-helm-chart-%:
 	cd helm-charts && helm dependency update $(*) && helm package $(*)

--- a/infra/dashboard-configs/metrics-server.yaml
+++ b/infra/dashboard-configs/metrics-server.yaml
@@ -78,7 +78,7 @@ spec:
     spec:
       serviceAccountName: metrics-server
       volumes:
-      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      # mount in tmp so we can safely use from-sratch images and/or read-only containers
       - name: tmp-dir
         emptyDir: {}
       containers:
@@ -88,6 +88,10 @@ spec:
         args:
           - --cert-dir=/tmp
           - --secure-port=4443
+          - --kubelet-insecure-tls
+          - --kubelet-preferred-address-types=InternalIP
+          - /metrics-server
+          - --v=2
         ports:
         - name: main-port
           containerPort: 4443

--- a/infra/helm-charts/mongo/templates/deployment.yaml
+++ b/infra/helm-charts/mongo/templates/deployment.yaml
@@ -35,3 +35,4 @@ spec:
       resources:
         requests:
           storage: 10Gi
+          memory: 2.7Gi

--- a/infra/helm-charts/neo4j/templates/deployment.yaml
+++ b/infra/helm-charts/neo4j/templates/deployment.yaml
@@ -30,3 +30,6 @@ spec:
             value: "neo4j/password"
           - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
             value: "yes"
+        resources:
+          requests:
+            memory: 2.8Gi

--- a/infra/helm-charts/rabbit/templates/deployment.yaml
+++ b/infra/helm-charts/rabbit/templates/deployment.yaml
@@ -39,3 +39,4 @@ spec:
       resources:
         requests:
           storage: 5Gi
+          memory: 200Mi

--- a/infra/helm-charts/redis/templates/deployment.yaml
+++ b/infra/helm-charts/redis/templates/deployment.yaml
@@ -39,3 +39,4 @@ spec:
       resources:
         requests:
           storage: 5Gi
+          memory: 100Mi

--- a/infra/helm-charts/vertical-autoscaling/Chart.lock
+++ b/infra/helm-charts/vertical-autoscaling/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: vpa
+  repository: https://charts.fairwinds.com/stable
+  version: 1.3.0
+- name: goldilocks
+  repository: https://charts.fairwinds.com/stable
+  version: 6.1.1
+digest: sha256:3a26c4952eb7f7b978f852b8f09692f7bf18cb1ad6d49d385a466c5f535a49ca
+generated: "2022-04-07T11:05:58.074664998+02:00"

--- a/infra/helm-charts/vertical-autoscaling/Chart.yaml
+++ b/infra/helm-charts/vertical-autoscaling/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ingest-vertical-autoscaling
+description: Chart for vertically autoscaling resources and providing a UI to manage it
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+dependencies:
+  - name: "vpa"
+    version: 1.3.0
+    repository: "https://charts.fairwinds.com/stable"
+  - name: "goldilocks"
+    version: 6.1.1
+    repository: "https://charts.fairwinds.com/stable"

--- a/infra/helm-charts/vertical-autoscaling/README.md
+++ b/infra/helm-charts/vertical-autoscaling/README.md
@@ -1,0 +1,21 @@
+# Vertical Autoscaling
+This chart enables vertical autoscaling (scaling of memory and CPU) using [Goldilocks](https://artifacthub.io/packages/helm/fairwinds-stable/goldilocks) and [VPA](https://artifacthub.io/packages/helm/fairwinds-stable/vpa). It's based on the guide [here](https://learnk8s.io/setting-cpu-memory-limits-requests).
+
+## What is it?
+VPA provides recommendations for a containers resource limits and requests and Goldilocks provides a nice UI to see these.
+
+## Using it
+1. Run `kubectl port-forward svc/vertical-autoscaling-goldilocks-dashboard 8080:80`
+1. Go to http://localhost:8080
+1. You can see the recommendations provided for each container in the UI
+1. You can then update the relevent `deployment.yaml` with the correct settings
+
+## Automatic setting of VPA recommendations
+In the dev environment the setting of recommendations is done automatically by Goldilocks. This is due to the `goldilocks.fairwinds.com/vpa-update-mode="auto"` label that is set on the `dev-environment` namespace. This is defined in `infra/Makefile`.
+
+This could be done for staging and prod too after some testing.
+
+## Deployment
+1. Go to the `infra` directory
+1. `source ../config/environment_<ENV>`
+1. `make install-infra-helm-chart-vertical-autoscaling`

--- a/infra/helm-charts/vertical-autoscaling/values.yaml
+++ b/infra/helm-charts/vertical-autoscaling/values.yaml
@@ -1,3 +1,11 @@
+vpa:
+  recommender:
+    extraArgs:
+      prometheus-address: localhost
+      storage: prometheus
+  admissionController:
+    enabled: true
+
 goldilocks:
   dashboard:
     replicaCount: 1

--- a/infra/helm-charts/vertical-autoscaling/values.yaml
+++ b/infra/helm-charts/vertical-autoscaling/values.yaml
@@ -1,0 +1,4 @@
+goldilocks:
+  dashboard:
+    replicaCount: 1
+  

--- a/infra/scripts/deploy_vertical_autoscaling.sh
+++ b/infra/scripts/deploy_vertical_autoscaling.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd helm-charts
+helm dependency update vertical-autoscaling && helm package vertical-autoscaling
+
+if [[ $* == '--upgrade' ]]
+then
+    helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install
+else
+    helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install --force
+fi
+
+rm *.tgz
+
+kubectl label ns $DEPLOYMENT_STAGE-environment goldilocks.fairwinds.com/enabled=true --overwrite
+
+
+if [ $DEPLOYMENT_STAGE == "dev" ]
+then
+    echo "Turning on auto VPA update";
+    kubectl label ns $DEPLOYMENT_STAGE-environment goldilocks.fairwinds.com/vpa-update-mode="auto" --overwrite
+fi

--- a/infra/scripts/deploy_vertical_autoscaling.sh
+++ b/infra/scripts/deploy_vertical_autoscaling.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+prometheus_IP=$(kubectl get svc -n gitlab-managed-apps -o jsonpath="{.items[?(@.metadata.name=='prometheus-prometheus-server')].spec.clusterIP}")
+
 cd helm-charts
 helm dependency update vertical-autoscaling && helm package vertical-autoscaling
 
 if [[ $* == '--upgrade' ]]
 then
-    helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install
+    helm upgrade --values vertical-autoscaling/values.yaml --set vpa.recommender.extraArgs.prometheus-address=$prometheus_IP vertical-autoscaling ./vertical-autoscaling --install
 else
-    helm upgrade --values vertical-autoscaling/values.yaml vertical-autoscaling ./vertical-autoscaling --install --force
+    helm upgrade --values vertical-autoscaling/values.yaml --set vpa.recommender.extraArgs.prometheus-address=$prometheus_IP vertical-autoscaling ./vertical-autoscaling --install --force
 fi
 
 rm *.tgz


### PR DESCRIPTION
dcp-651 and dcp-741

- Fixes metrics-server 
- Adds resource requests and limits that I estimated using prior logs from Prometheus
- Adds a vertical autoscaler that provides recommendations of values to use for memory and CPU resource limits
  - in dev these limits are applied automatically
    - We could consider doing this in staging and prod too but needs to be tested first

![image](https://user-images.githubusercontent.com/5579270/162192404-bffbce98-5f8a-47b6-9f3a-70dde903c6b8.png)


# Deploying this PR
In order to deploy these changes do the following in each environment

1. `cd infra/dashboard-configs && kubectl apply -f metrics-server.yaml`
1. Deploy vertical-autoscaling (see README)
1. Re-deploy each container using GitLab
