### PR TITLE
dcp-958 fix gitlab runner registration

### DIFF
--- a/apps/secrets/templates/deployment.yaml
+++ b/apps/secrets/templates/deployment.yaml
@@ -23,8 +23,8 @@ data:
   exporter-access-key-secret: {{ .Values.awsKeys.exporterAccessKeySecret }}
   notifications-smtp-username: {{ .Values.awsKeys.notificationsSmtpUsername }}
   notifications-smtp-password: {{ .Values.awsKeys.notificationsSmtpPassword }}
-  runner-registration-token: {{ .Values.awsKeys.gitlabGroupRunnerToken }}
-  runner-token: ""
+  runner-registration-token: ""
+  runner-token: {{ .Values.awsKeys.gitlabGroupRunnerToken }}
 stringData:
   grafana-admin-username: {{ .Values.awsKeys.grafanaAdminUsername }}
   grafana-admin-password: {{ .Values.awsKeys.grafanaAdminPassword }}


### PR DESCRIPTION
switch between `runner-registration-token` and `runner-token`.
See https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html

dcp-958
ebi-ait/dcp-ingest-central#958